### PR TITLE
Support more/less than 4 panels.

### DIFF
--- a/js/boxesFx.js
+++ b/js/boxesFx.js
@@ -67,7 +67,7 @@
 		// the panels
 		this.panels = [].slice.call( this.el.querySelectorAll( '.panel' ) );
 		// total number of panels (4 for this demo)
-		//this.panelsCount = this.panels.length;
+		this.slidesCount = this.panels.length;
 		this.panelsCount = 4;
 		// current panel´s index
 		this.current = 0;
@@ -157,10 +157,10 @@
 		var self = this, currentPanel = this.panels[ this.current ];
 
 		if( dir === 'next' ) {
-			this.current = this.current < this.panelsCount - 1 ? this.current + 1 : 0;			
+			this.current = this.current < this.slidesCount - 1 ? this.current + 1 : 0;			
 		}
 		else {
-			this.current = this.current > 0 ? this.current - 1 : this.panelsCount - 1;
+			this.current = this.current > 0 ? this.current - 1 : this.slidesCount - 1;
 		}
 
 		// next panel to be shown


### PR DESCRIPTION
The next panel was selected incorrectly if the number of panel was not equal to 4. It will now work for panel count less than or greater than 4. (named the count variable as slidesCount as panelsCount was already being used and the image replacement uses it)
